### PR TITLE
Add option for passing extra request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ options object:
  * `useArray` &ndash; Changes the `FormData` name of the `file` to either `file[]` or `file`;
  * `mimeTypes` &ndash; List of valid MIME types &ndash; can also be changed with `mimeTypes` method;
  * `requestHeaders` &ndash; Additional request headers to be sent;
+ * `requestOptions` &ndash; Additional request options;
  * `requestPostData` &ndash; Additional POST data to be sent;
 
 ```javascript

--- a/components/Droplet.js
+++ b/components/Droplet.js
@@ -192,6 +192,12 @@
         requestHeaders: {},
 
         /**
+         * @property requestOptions
+         * @type {Object}
+         */
+        requestOptions: {},
+
+        /**
          * @property requestPostData
          * @type {Object}
          */
@@ -488,6 +494,7 @@
             const method     = get(this, 'options.requestMethod') || 'POST';
             const data       = this.getFormData();
             const headers    = $Ember.merge({}, this.get('options.requestHeaders'));
+            const options    = $Ember.merge({}, this.get('options.requestOptions'));
 
             if (get(this, 'options.includeXFileSize')) {
                 headers['X-File-Size'] = this.get('requestSize');
@@ -506,8 +513,9 @@
                     set(this, 'lastRequest', xhr);
                     return xhr;
 
-                }
+                },
 
+                ...options
             });
 
             set(this, 'lastResolver', request);


### PR DESCRIPTION
Add an option, `requestOptions`, for passing extra options with requests
sent from Droplet.
